### PR TITLE
Success.call signature should take unwrapped value

### DIFF
--- a/play.promises/src/org/osgi/util/promise/Deferred.java
+++ b/play.promises/src/org/osgi/util/promise/Deferred.java
@@ -165,7 +165,7 @@ public class Deferred<T> {
 		private <R> void success(final Deferred<R> nextStage,
 				final Success<R, T> ok) throws Exception {
 			try {
-				final Promise<R> nextResult = ok.call(this);
+				final Promise<R> nextResult = ok.call(value);
 				if (nextResult == null) {
 
 					//

--- a/play.promises/src/org/osgi/util/promise/Success.java
+++ b/play.promises/src/org/osgi/util/promise/Success.java
@@ -16,5 +16,5 @@ public interface Success<Return,Value> {
 	 * @param promise
 	 * @return
 	 */
-	Promise<Return> call(Promise<Value> promise) throws Exception;
+	Promise<Return> call(Value value) throws Exception;
 }

--- a/play.promises/src/play/promises/client/Client.java
+++ b/play.promises/src/play/promises/client/Client.java
@@ -36,9 +36,9 @@ public class Client {
 		p.then(new Success<String, String>() {
 
 			@Override
-			public Promise<String> call(Promise<String> promise) throws Exception {
+			public Promise<String> call(String value) throws Exception {
 				System.out.println("In ");
-				System.out.println( promise.get());
+				System.out.println(value);
 				return async.call(actualAsync.foo(4));
 			}
 		}, failure);

--- a/play.promises/test/play/comsrv/SelfieTest.java
+++ b/play.promises/test/play/comsrv/SelfieTest.java
@@ -28,9 +28,9 @@ public class SelfieTest extends TestCase {
 		Success<String, String> triple = new Success<String, String>() {
 
 			@Override
-			public Promise<String> call(Promise<String> promise)
+			public Promise<String> call(String value)
 					throws Exception {
-				return selfie.send("***" + promise.get() + "***");
+				return selfie.send("***" + value + "***");
 			}
 		};
 		String s = selfie.send("Hello").then(triple).then(triple).get();

--- a/play.promises/test/test/PromiseTest.java
+++ b/play.promises/test/test/PromiseTest.java
@@ -30,11 +30,11 @@ public class PromiseTest extends TestCase {
 		Success<String, String> doubler = new Success<String, String>() {
 
 			@Override
-			public Promise<String> call(Promise<String> promise)
+			public Promise<String> call(String value)
 					throws Exception {
-				System.out.println("get : " + promise.get());
+				System.out.println("get : " + value);
 				s.release();
-				return Deferred.getDirectPromise(promise.get() + promise.get());
+				return Deferred.getDirectPromise(value + value);
 			}
 		};
 
@@ -122,10 +122,10 @@ public class PromiseTest extends TestCase {
 		Success<String, String> doubler = new Success<String, String>() {
 
 			@Override
-			public Promise<String> call(Promise<String> promise)
+			public Promise<String> call(String value)
 					throws Exception {
-				System.out.println(promise.get());
-				return Deferred.getDirectPromise(promise.get() + promise.get());
+				System.out.println(value);
+				return Deferred.getDirectPromise(value + value);
 			}
 		};
 		final Promise<String> p2 = p1.then(doubler).then(doubler).then(doubler);
@@ -231,11 +231,11 @@ public class PromiseTest extends TestCase {
 		Promise<Integer> p2 = p1.then(new Success<Integer, String>() {
 
 			@Override
-			public Promise<Integer> call(Promise<String> promise)
+			public Promise<Integer> call(String value)
 					throws Exception {
 				s.release();
 
-				return Deferred.getDirectPromise(Integer.parseInt(promise.get()));
+				return Deferred.getDirectPromise(Integer.parseInt(value));
 			}
 		});
 		assertEquals(Integer.valueOf(10), p2.get());
@@ -250,9 +250,9 @@ public class PromiseTest extends TestCase {
 		Promise<Integer> p2 = p1.then(new Success<Integer, String>() {
 
 			@Override
-			public Promise<Integer> call(final Promise<String> promise)
+			public Promise<Integer> call(final String value)
 					throws Exception {
-				return async(promise.get());
+				return async(value);
 			}
 
 		});


### PR DESCRIPTION
Changed the Success.call signature to take the unwrapped value of the previous Promise, rather than that Promise itself.
