### PR TITLE
Add a test which shows an issue with the current async delegation model

### DIFF
--- a/play.promises/test/test/AsyncTest.java
+++ b/play.promises/test/test/AsyncTest.java
@@ -1,6 +1,7 @@
 package test;
 
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
 
 import junit.framework.TestCase;
 
@@ -85,4 +86,56 @@ public class AsyncTest extends TestCase {
 		
 		System.out.println("done");
 	}
+	
+	
+	/**
+	 * Demonstrate an issue with nested asynchronous calls
+	 * 
+	 * If a service makes a call to an asynchronous one within the
+	 * scope of a mediated call then it usurps the returned promise.
+	 * 
+	 * In this test the async part returns "async". The overall service
+	 * is supposed to return "nested async", but doesn't because the
+	 * async service creates a deferred which overrides the promise. 
+	 */
+	public void testNested() throws Exception {
+		Async async = new AsyncImpl();
+
+		/* A simple AsyncFoo that will be delegated to */
+		final ASyncFoo delegate = new ASyncFoo("async");
+		delegate.setAsync(async);
+		
+		/* A delegating foo implementation that prepends "nested " to the result */
+		Foo delegating = new Foo() {
+			@Override
+			public String foo(int delay) {
+				return "nested "+ delegate.foo(delay);
+			}
+		};
+		
+		/* Calling the real service should give "nested async" */
+		assertEquals( "nested async", delegating.foo(1));
+
+		Foo msf = async.mediate(delegating);
+		
+		Promise<String> p = async.hold(msf.foo(2));
+		
+		final Semaphore s = new Semaphore(0);
+		
+		p.onresolve(new Runnable(){
+
+			@Override
+			public void run() {
+				s.release();
+			}});
+
+		p.launch();
+		s.tryAcquire(3000, TimeUnit.MILLISECONDS);
+		
+		/* This fails because the async usurps the return */
+		assertEquals( "nested async", p.get());
+		
+		System.out.println("done");
+	}
+	
 }


### PR DESCRIPTION
The original RFC draft had an SPI interface which meant that a service knew when it was being directly called by the async service. This new prototype uses a ThreadLocal, which causes problems when a non async-aware service calls an async-aware service.

I have added a test case which demonstrates the issue.
